### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,74 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{ secrets.DOCKER_USERNAME }}/${GITHUB_REPOSITORY#*/}
+          VERSION=latest
+          SHORTREF=${GITHUB_SHA::8}
+
+          # If this is git tag, use the tag name as a docker tag
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
+
+          # If the VERSION looks like a version number, assume that
+          # this is the most recent version of the image and also
+          # tag it 'latest'.
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+          fi
+
+          # Set output parameters.
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+CMD /go/src/app/docker.sh

--- a/README.md
+++ b/README.md
@@ -34,14 +34,17 @@ sudo journalctl -f -u energybridge-to-influxdb.service
 
 ## Usage
 
-* `-client-id`: MQTT Client ID. Defaults to hostname. (default "fermi")
-* `-energy-bridge-host`: IP or host of the Energy Bridge, eg. '192.168.1.1'. Required.
-* `-energy-bridge-nametag`: Value for the energy_bridge_name tag in InfluxDB. Required.
-* `-influx-bucket`: InfluxDB bucket. Supply a string in the form 'database/retention-policy'. For the default retention policy, pass just a database name (without the slash character). Required.
-* `-influx-password`: InfluxDB password.
-* `-influx-server`: InfluxDB server, including protocol and port, eg. 'http://192.168.1.1:8086'. Required.
-* `-influx-username`: InfluxDB username.
+* `-client-id`: MQTT Client ID. Defaults to hostname. (default "fermi"). `CLIENT_ID` env for Docker.
+* `-energy-bridge-host`: IP or host of the Energy Bridge, eg. '192.168.1.1'. Required. `BRIDGE_HOST` env for Docker.
+* `-energy-bridge-nametag`: Value for the energy_bridge_name tag in InfluxDB. Required. `BRIDGE_NAME_TAG` env for Docker.
+* `-influx-bucket`: InfluxDB bucket. Supply a string in the form 'database/retention-policy'. For the default retention policy, pass just a database name (without the slash character). Required. `INFLUX_BUCKET` env for Docker.
+* `-influx-password`: InfluxDB password. `INFLUX_PASSWORD` env for Docker.
+* `-influx-server`: InfluxDB server, including protocol and port, eg. 'http://192.168.1.1:8086'. Required. `INFLUX_SERVER` env for Docker.
+* `-influx-username`: InfluxDB username. `INFLUX_USERNAME` env for Docker.
 * `-print-usage`: Pass this flag to log every usage message to standard error.
+
+## Docker
+A docker iamge is also provided that can be configured via environment variables.
 
 ## License
 

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+warn () {
+    echo "$@" >&2
+}
+die () {
+    rc=$1
+    shift
+    warn "$@"
+    exit $rc
+}
+
+# check for required envs
+if [[ -z "${BRIDGE_HOST}" ]]; then
+    die 1 "BRIDGE_HOST is a required environment variables that is missing"
+fi
+
+if [[ -z "${BRIDGE_NAME_TAG}" ]]; then
+    die 1 "BRIDGE_NAME_TAG is a required environment variables that is missing"
+fi
+
+if [[ -z "${INFLUX_BUCKET}" ]]; then
+    die 1 "BRIDGE_NAME_TAG is a required environment variables that is missing"
+fi
+
+if [[ -z "${INFLUX_SERVER}" ]]; then
+    die 1 "BRIDGE_NAME_TAG is a required environment variables that is missing"
+fi
+
+# parse envs to create cmd args
+args=""
+
+if [[ $CLIENT_ID ]]; then
+    args="$args -client-id $CLIENT_ID"
+fi
+
+if [[ $BRIDGE_HOST ]]; then
+    args="$args -energy-bridge-host $BRIDGE_HOST"
+fi
+
+if [[ $BRIDGE_NAME_TAG ]]; then
+    args="$args -energy-bridge-nametag $BRIDGE_NAME_TAG"
+fi
+
+if [[ $INFLUX_BUCKET ]]; then
+    args="$args -influx-bucket $INFLUX_BUCKET"
+fi
+
+if [[ $INFLUX_SERVER ]]; then
+    args="$args -influx-server $INFLUX_SERVER"
+fi
+
+if [[ $INFLUX_USERNAME ]]; then
+    args="$args -influx-username $INFLUX_USERNAME"
+fi
+
+if [[ $INFLUX_PASSWORD ]]; then
+    args="$args -influx-password $INFLUX_PASSWORD"
+fi
+
+energybridge_to_influxdb $args


### PR DESCRIPTION
This adds a docker image and also enabled GitHub to build and push the image to docker hub. The following secrets need to be added to the repo in order for this to work:

- `DOCKER_USERNAME` Docker Hub Username
- `DOCKER_PASSWORD` Docker Hub Password

This will enable docker image builds for multiple platforms:

- linux/amd64
- linux/arm64
- linux/386
- linux/arm/v7
- linux/arm/v6